### PR TITLE
sheet#addImage に外から画像位置を指定できる引数を追加した

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1080,7 +1080,7 @@ export type ConditionalFormattingRule = ExpressionRuleType | CellIsRuleType | To
 	| ContainsTextRuleType | TimePeriodRuleType | DataBarRuleType;
 
 
-export type RowValues = CellValue[] | { [key: string]: CellValue } | undefined | null; 
+export type RowValues = CellValue[] | { [key: string]: CellValue } | undefined | null;
 
 export interface ConditionalFormattingOptions {
 	ref: string;
@@ -1192,14 +1192,14 @@ export interface Worksheet {
 
 	/**
 	 * Tries to find and return row for row no, else undefined
-	 * 
+	 *
 	 * @param row The 1-index row number
 	 */
 	findRow(row: number): Row | undefined;
 
 	/**
 	 * Tries to find and return rows for row no start and length, else undefined
-	 * 
+	 *
 	 * @param start The 1-index starting row number
 	 * @param length The length of the expected array
 	 */
@@ -1333,7 +1333,12 @@ export interface Worksheet {
 	 * Using the image id from `Workbook.addImage`,
 	 * embed an image within the worksheet to cover a range
 	 */
-	addImage(imageId: number, range: string | { editAs?: string; } & ImageRange & { hyperlinks?: ImageHyperlinkValue } | { editAs?: string; } & ImagePosition & { hyperlinks?: ImageHyperlinkValue }): void;
+	 addImage(imageId: number, range: string | { editAs?: string; } & ImageRange & { hyperlinks?: ImageHyperlinkValue } | { editAs?: string; } & ImagePosition & { hyperlinks?: ImageHyperlinkValue } | { tl: {
+		nativeCol: number;
+		nativeRow: number;
+		nativeColOff: number;
+		nativeRowOff: number;}} & {ext: { width: number; height: number }}
+	): void;
 
 	getImages(): Array<{
 		type: 'image',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`sheet#addImage` に引数のパターンを追加した
配置したいセルの位置と画像のサイズを指定して画像を挿入したい時に、使える選択肢が[こちら](https://github.com/tkm-kj/exceljs/blob/860b862d122c2645f8b34f0f885a64b104f7a538/index.d.ts#L917-L920)しかなかった（ように見えている）
そして、こちらを使うと狙った位置と違うところに画像が挿入されてしまう
原因としては
https://github.com/tkm-kj/exceljs/blob/860b862d122c2645f8b34f0f885a64b104f7a538/lib/doc/anchor.js#L44-L47
https://github.com/tkm-kj/exceljs/blob/860b862d122c2645f8b34f0f885a64b104f7a538/lib/doc/anchor.js#L53-L56
の計算が期待した動きと違うため。[こちら](https://github.com/tkm-kj/exceljs/commit/0703db43f7ad849d98f3311ff8959750fa0fd6a8)で一瞬なんとかしようと試みたが、高さは期待した動きをするようになったが幅の位置は適切に変わらなかった

画像の位置を決める画像の col, row, colOff, rowOff の指定されてる場所を調べたら、[こちら](https://github.com/tkm-kj/exceljs/blob/860b862d122c2645f8b34f0f885a64b104f7a538/lib/xlsx/xform/drawing/cell-position-xform.js#L20-L24)でやっていることがわかった。そして、 `model` が指しているものは `Anchor` だった
以上から、直接 nativeCol, nativeColOff, nativeRow, nativeRowOff を外から渡したらどうにかなるのではと判断して実装して繋いでみたら上手く動くようになった

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
